### PR TITLE
I15 - Gerar documentação de código de forma automatizada.

### DIFF
--- a/docs/cod-docs/_index.rst
+++ b/docs/cod-docs/_index.rst
@@ -6,3 +6,5 @@ Code Docs
    :maxdepth: 2
    
    ej
+   ej_clusters
+   ej_conversations

--- a/docs/cod-docs/_index.rst
+++ b/docs/cod-docs/_index.rst
@@ -1,0 +1,8 @@
+#########
+Code Docs
+#########
+
+.. toctree::
+   :maxdepth: 2
+   
+   ej

--- a/docs/cod-docs/ej.rst
+++ b/docs/cod-docs/ej.rst
@@ -1,0 +1,6 @@
+##
+EJ
+##
+
+.. automodule:: src.ej.forms
+    :members:

--- a/docs/cod-docs/ej_clusters.rst
+++ b/docs/cod-docs/ej_clusters.rst
@@ -1,0 +1,7 @@
+###########
+EJ Clusters 
+###########
+
+.. automodule:: src.ej_clusters.rules
+    :members:
+

--- a/docs/cod-docs/ej_conversations.rst
+++ b/docs/cod-docs/ej_conversations.rst
@@ -1,0 +1,8 @@
+################
+EJ Conversations
+################
+
+.. automodule:: src.ej_conversations.rules
+    :members:
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,8 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.append(os.path.abspath('../'))
+
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ import sys
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -24,7 +24,8 @@ import sys
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = []
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage',
+              'sphinx.ext.napoleon']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates', '../src/ej/templates/jinja2']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,3 +7,4 @@ Welcome to EJ documentation!
    user-guide/_index
    dev-docs/_index
    i18n/index
+   cod-docs/_index

--- a/src/ej/forms.py
+++ b/src/ej/forms.py
@@ -1,7 +1,7 @@
 """
 forms.py
 ====================================
-Forms django project 
+Forms django project
 """
 
 from operator import attrgetter

--- a/src/ej/forms.py
+++ b/src/ej/forms.py
@@ -1,3 +1,9 @@
+"""
+forms.py
+====================================
+Forms django project 
+"""
+
 from operator import attrgetter
 
 from django.forms import Form, ModelForm, widgets

--- a/src/ej_conversations/roles/conversations.py
+++ b/src/ej_conversations/roles/conversations.py
@@ -111,7 +111,8 @@ def conversation_create_comment(conversation, request=None, **kwargs):
     #     id="create-comment",
     # )
     return div(
-        Blob(f'<div style="position: relative; top: 40px;" class="text-7 strong">{comments_count}<br>{moderation_msg}</div>'),
+        Blob(f'<div style="position: relative; top: 40px;"
+             class="text-7 strong">{comments_count}<br>{moderation_msg}</div>'),
         id="create-comment",
         class_="extra-content",
     )

--- a/src/ej_gamification/routes.py
+++ b/src/ej_gamification/routes.py
@@ -15,6 +15,7 @@ urlpatterns = Router(template="ej_gamification/{name}.jinja2", login=True)
 sign = lambda x: 1 if x >= 0 else -1
 pd = import_later("pandas")
 
+
 @urlpatterns.route("achievements/")
 def achievements(request):
     user = request.user


### PR DESCRIPTION
# Descrição
  Gera documentação de código de forma automatizada.

## Issues Relacionadas
 https://github.com/gces-empjuntos/ej-server/issues/15

## Checklist  
- [x] A documentação de código deve ser gerada automaticamente a partir dos comentários inseridos no próprio código.

Ao tentar rodar o configure.sh obtive um erro do Django quando cria "createfakeconversations" como segue a imagem.

![image](https://user-images.githubusercontent.com/34287081/66792162-06c5e780-eee7-11e9-936d-e8e7e448f4d7.png)

Não tenho certeza mas acho que isso afetou o funcionamento do sphinx pois alguns arquivos python deram erros ao tentar gerar a documentação.

![image](https://user-images.githubusercontent.com/34287081/66792230-586e7200-eee7-11e9-9e16-37567578611b.png)

Gostaria de pedir que possam verificar em suas maquinas que não possuem o mesmo erro do django citado acima e se esses outros 2 docs que estão dando erro funcionam corretamente.

Há arquivos sem depende cia que deram certo como o "forms" do EJ. Então considero que a issue foi resolvida por está gerando a documentação de código de forma automatizada como segue a imagem. Como issue futura sugiro a adição de documentação nos códigos para que o sphinx possa pegar o cabeçalho de forma correta e a adição de todos os outros códigos que não entraram.

![image](https://user-images.githubusercontent.com/34287081/66792332-af744700-eee7-11e9-9d6e-89fc9a666266.png)

