### PR TITLE
REVIEW - I16 percentage spacing

### DIFF
--- a/lib/scss/components/conversations/_card.scss
+++ b/lib/scss/components/conversations/_card.scss
@@ -52,6 +52,15 @@ $_card-bg: config('ej.conversation-card.bg-image');
             font-weight: 600;
         }
     }
+    &__footer {
+        width: 100%;
+        height: 105px;
+    }
+    &__author {
+        order: 1;
+        margin-top: 0;
+        margin-bottom: 5px
+    }
     &__moderate {
         @include utilities('uppercase text-6 margin-2 bold');
 
@@ -66,6 +75,8 @@ $_card-bg: config('ej.conversation-card.bg-image');
         }
         background-blend-mode: luminosity;
         width: 100%;
+        order: 1;
+        margin: 0, auto;
     }
 
     .progress-bar {

--- a/src/ej_conversations/jinja2/ej/role/conversation-card.jinja2
+++ b/src/ej_conversations/jinja2/ej/role/conversation-card.jinja2
@@ -11,12 +11,20 @@
         <li>{{ span_icon(n_votes, 'sliders-h') }}</li>
         <li>{{ span_icon(n_favorites, 'star') }}</li>
     </ul>
-    <h2 class="conversation-card__text">
+    <h2 class="conversation-card__text" style="margin-top: 0;">
         <a href="{{ url }}">{{ text }}</a>
     </h2>
-    <div class="conversation-card__author" style="order: 1">{{ _('by:') }} <strong>{{ author }}</strong></div>
-    {{ progress or '' }}
-    <div class="conversation-card__button" style="order: 1">{{ action_button(_('Participate now!'), url, tabindex=-1, aria_hidden="true") }}</div>
+    <div style="width: 100%">
+        <div class="conversation-card__author" style="order: 1; margin-top: 0; margin-bottom: 5px">
+            {{ _('by:') }} <strong>{{ author }}</strong>
+        </div>
+        {{ progress or '' }}
+        <div class="conversation-card__button" style="order: 1; margin: 0 auto;" >
+            {{ action_button(_('Participate now!'), url, tabindex=-1, aria_hidden="true") }}
+        </div>
+    </div>
+
+    
 </div>
 
 

--- a/src/ej_conversations/jinja2/ej/role/conversation-card.jinja2
+++ b/src/ej_conversations/jinja2/ej/role/conversation-card.jinja2
@@ -14,12 +14,12 @@
     <h2 class="conversation-card__text" style="margin-top: 0;">
         <a href="{{ url }}">{{ text }}</a>
     </h2>
-    <div style="width: 100%">
-        <div class="conversation-card__author" style="order: 1; margin-top: 0; margin-bottom: 5px">
+    <div class="conversation-card__footer">
+        <div class="conversation-card__author">
             {{ _('by:') }} <strong>{{ author }}</strong>
         </div>
         {{ progress or '' }}
-        <div class="conversation-card__button" style="order: 1; margin: 0 auto;" >
+        <div class="conversation-card__button">
             {{ action_button(_('Participate now!'), url, tabindex=-1, aria_hidden="true") }}
         </div>
     </div>


### PR DESCRIPTION
# Descrição
Antes, o tamanho dos footers dos cards variava quanto o título tinha 2 ou 3 perguntas.

Agora o tamanho está fixo e funciona para qualquer número de linhas abaixo de 4.

## Issues Relacionadas
#16

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

## Imagens/Comentários
  <!--Insira imagens(prints ou gifs) com comentários sobre as mudanças (caso seja frontend)-->
![image](https://user-images.githubusercontent.com/29482983/67327824-ed2c2d80-f4ee-11e9-95d6-2b0219ee2d6e.png)
