### PR TITLE
REVIEW - Fixed position of over comment card

### DIFF
--- a/lib/scss/components/conversations/_detail.scss
+++ b/lib/scss/components/conversations/_detail.scss
@@ -151,6 +151,8 @@ $component-border-radius: size(config('ej.style.border-radius'));
     @include utilities('center text-black');
     @include themed('background', light);
 
+    height: 360px;
+
     label {
         @include utilities('regular margin-b2 text-black');
         text-transform: none;

--- a/src/ej_conversations/jinja2/ej/role/conversation-comment-form.jinja2
+++ b/src/ej_conversations/jinja2/ej/role/conversation-comment-form.jinja2
@@ -2,7 +2,7 @@
     {% if user == None %}
         <p>{% trans %}Please {{ login_anchor }} to vote on this conversation.{% endtrans %}</p>
     {% elif comments_exceeded|default(False) %}
-        <h3>{% trans %}Ooops!{% endtrans %}</h3>
+        <h3 style="margin-top: 80px;">{% trans %}Ooops!{% endtrans %}</h3>
         <p>{% trans %}You reached the limit of comments in this conversation.{% endtrans %}</p>
     {% else %}
         {% set n_comments_span = '<em class="text-accent roman">{n}</em>'.format(n=n_comments)|safe %}


### PR DESCRIPTION
# Descrição
Conserta um problema no comment-card no caso de número de cards excedidos. A div era muito pequena, então certas coisas eram puxadas para cima de um jeito que não deveriam ser.

## Issues Relacionadas
Me falaram pra fazer isso relacionando a Issue #23, embora o problema dela nem exista mais :v

## Checklist  
- [x] Os commits seguem o padrão do projeto (Flake8 e afins)
- [x] Os testes estão passando e cobrem as mudanças 
- [x] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

## Imagens/Comentários

### Antigo
![image](https://user-images.githubusercontent.com/29482983/67521871-192be800-f682-11e9-92e2-f06478ef4ef3.png)

### Novo
![image](https://user-images.githubusercontent.com/29482983/67521934-32349900-f682-11e9-83ee-ef3c65c85c99.png)
