### PR TITLE
[REVIEW] - Ativar geolocalização para a informação de Cidade/UF no perfil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ djangorestframework = "^3.9"
 django-debug-toolbar = "^1.11"
 openpyxl = "^2.6"
 django-picklefield = "^2.0"
-
+geocoder = "1.38.1"
 
 [tool.poetry.dev-dependencies]
 mock = "^2.0"
@@ -74,7 +74,7 @@ toml = "^0.10.0"
 pre-commit = "^1.17"
 notebook = "^6.0"
 django-picklefield = "^2.0"
-
+geocoder = "^1.38.1"
 
 [tool.black]
 line-length = 108  # Strict maximum of 120

--- a/src/ej_profiles/forms.py
+++ b/src/ej_profiles/forms.py
@@ -44,7 +44,6 @@ class ProfileForm(EjModelForm):
             # they show as blanks
             # "birth_date": DateInput(attrs={"type": "date"}, format="D d M Y"),
             # "profile_photo": ej.forms.FileInput(attrs={"accept": "image/*"})
-            "state": forms.Select(choices=STATE_CHOICES)
         }
 
     def __init__(self, *args, instance, **kwargs):

--- a/src/ej_profiles/routes.py
+++ b/src/ej_profiles/routes.py
@@ -36,16 +36,12 @@ def edit(request):
     ip_adr = get_client_ip(request)
     
     location = get_loc(ip_adr)
-    print(ip_adr)
+    
     if form.is_valid_post():
         form.files = request.FILES
-        if location.country and location.state and location.city is not None:
-            if not profile.country:
-                profile.country = location.country
-            if not profile.state:
-                profile.state = location.state
-            if not profile.city:
-                profile.city = location.city
+        
+        if location.country is not None:
+            profile = check_location(profile, location)
         
         form.save()
 
@@ -59,6 +55,17 @@ def edit(request):
     state = models.CharField(_("State"), blank=True, max_length=3)
     city = models.CharField(_("City"), blank=True, max_length=140)
     
+
+def check_location(profile, location):
+    if not profile.country:
+        profile.country = location.country
+    if not profile.state:
+        profile.state = location.state
+    if not profile.city:
+        profile.city = location.city
+    
+    return profile        
+
 
 @urlpatterns.route("contributions/")
 def contributions(request):

--- a/src/ej_profiles/routes.py
+++ b/src/ej_profiles/routes.py
@@ -39,13 +39,14 @@ def edit(request):
     print(ip_adr)
     if form.is_valid_post():
         form.files = request.FILES
-        if not profile.country and location.country is not None:
-            profile.country = location.country
-        if not profile.state and location.state is not None:
-            profile.state = location.state
-        if not profile.city and location.city is not None:
-            profile.city = location.city
-    
+        if location.country and location.state and location.city is not None:
+            if not profile.country:
+                profile.country = location.country
+            if not profile.state:
+                profile.state = location.state
+            if not profile.city:
+                profile.city = location.city
+        
         form.save()
 
         from pprint import pprint

--- a/src/ej_profiles/routes.py
+++ b/src/ej_profiles/routes.py
@@ -35,21 +35,20 @@ def edit(request):
 
     ip_adr = get_client_ip(request)
     
-    location = get_loc('172.68.27.22')
-
+    location = get_loc(ip_adr)
+    print(ip_adr)
     if form.is_valid_post():
         form.files = request.FILES
-        if not profile.country:
+        if not profile.country and location.country is not None:
             profile.country = location.country
-        if not profile.state:
+        if not profile.state and location.state is not None:
             profile.state = location.state
-        if not profile.city:
+        if not profile.city and location.city is not None:
             profile.city = location.city
-        
+    
         form.save()
 
         from pprint import pprint
-        print(form)
         pprint(form.cleaned_data)
         return redirect("/profile/")
 

--- a/src/ej_profiles/routes.py
+++ b/src/ej_profiles/routes.py
@@ -35,12 +35,14 @@ def edit(request):
 
     ip_adr = get_client_ip(request)
     
-    location = get_loc(ip_adr)
+    location = get_loc('172.68.27.22')
 
     if form.is_valid_post():
         form.files = request.FILES
         if not profile.country:
             profile.country = location.country
+        if not profile.state:
+            profile.state = location.state
         if not profile.city:
             profile.city = location.city
         

--- a/src/ej_profiles/routes.py
+++ b/src/ej_profiles/routes.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from ej_conversations.models import Conversation, Comment
 from . import forms
+from .utils import get_loc
 
 app_name = "ej_profiles"
 urlpatterns = Router(template=["ej_profiles/{name}.jinja2", "generic.jinja2"], login=True)
@@ -31,6 +32,8 @@ def detail(request):
 def edit(request):
     profile = request.user.get_profile()
     form = forms.ProfileForm(instance=profile, request=request)
+    
+    ip_adr = str(request.remote_addr)
 
     if form.is_valid_post():
         form.files = request.FILES

--- a/src/ej_profiles/utils.py
+++ b/src/ej_profiles/utils.py
@@ -23,6 +23,5 @@ def get_loc(ip_adr):
     Method to get a lat and log from an ip
     """
     location = geocoder.ip(ip_adr)
-    
-    print(location)
+
     return(location)

--- a/src/ej_profiles/utils.py
+++ b/src/ej_profiles/utils.py
@@ -10,6 +10,14 @@ def years_from(date, now=None):
         return years - 1
     return years
 
+def get_client_ip(request):
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[0]
+    else:
+        ip = request.META.get('REMOTE_ADDR')
+    return ip
+
 def get_loc(ip_adr):
     """
     Method to get a lat and log from an ip

--- a/src/ej_profiles/utils.py
+++ b/src/ej_profiles/utils.py
@@ -1,3 +1,5 @@
+import geocoder
+
 from django.utils import timezone
 
 
@@ -7,3 +9,12 @@ def years_from(date, now=None):
     if date.month > now.month or (date.month == now.month and date.day > now.day):
         return years - 1
     return years
+
+def get_loc(ip_adr):
+    """
+    Method to get a lat and log from an ip
+    """
+    location = geocoder.ip(ip_adr)
+    
+    print(location)
+    return(location)


### PR DESCRIPTION
# Descrição
  <!--Descreva as modificações e impactos deste pull request -->
Foi adicionado a população automática das informações no perfil caso o usuário não tenha preenchido as informações

## Issues Relacionadas
  <!-- Quais issues estão relacionadas e.g. "resolves: #numDaIssue" -->
#21 

## Checklist  
- [X] Os commits seguem o padrão do projeto (Flake8 e afins)
- [ ] Os testes estão passando e cobrem as mudanças 
- [X] Marcou no título do pull request se ele é work in progress [WIP] ou se está pronto para revisão [REVIEW]

## Imagens/Comentários
  <!--Insira imagens(prints ou gifs) com comentários sobre as mudanças (caso seja frontend)-->
Para testar o PR no local é necessário usar um ip pois ao subir localmente a requisição irá usar o ip local da sua maquina. 

Vá em:
.../ej-server/src/ej_profiles/routes.py

e modifique a linha 
    location = get_loc(ip_adr)
para
    location = get_loc("172.68.29.144")
caso deseje testar um ip no Brasil